### PR TITLE
Baseline USB functionality verified

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,3 +14,11 @@ board = genericSTM32F412RG
 framework = arduino
 upload_protocol = stlink
 debug_tool = stlink
+build_flags =
+	-D PIO_FRAMEWORK_ARDUINO_ENABLE_CDC
+	-D USBCON
+	-D USBD_VID=0xCAB0
+	-D USBD_PID=0x0003
+    -D HAL_PCD_MODULE_ENABLED
+    -D USB_MANUFACTURER_STRING="\"HPVDT\""
+    -D USB_PRODUCT_STRING="\"Falcon Motherboard\""

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,16 @@ const int testPin = PB5;
 
 void setup() {
   pinMode(testPin, OUTPUT);
+
+  SerialUSB.begin();
+  while (!SerialUSB) delay(10); // Wait for USB connection to be made to the computer before continuing
 }
 
 void loop() {
+  SerialUSB.println(millis());
+
   digitalWrite(testPin, HIGH);
-  delay(2000);
+  delay(20);
   digitalWrite(testPin, LOW);
-  delay(2000);
+  delay(20);
 }


### PR DESCRIPTION
Issues found in hardware, USB D+ and D- signal are going to the wrong pins on the MCU of the rev. 1 board.